### PR TITLE
Allow multiple record names in internal hostname annotation for pods

### DIFF
--- a/source/pod_test.go
+++ b/source/pod_test.go
@@ -111,6 +111,46 @@ func TestPodSource(t *testing.T) {
 			},
 		},
 		{
+			"split record for internal hostname annotation",
+			"",
+			"",
+			[]*endpoint.Endpoint{
+				{DNSName: "internal.a.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},
+				{DNSName: "internal.b.foo.example.org", Targets: endpoint.Targets{"10.0.1.1"}, RecordType: endpoint.RecordTypeA},
+			},
+			false,
+			[]*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-node1",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{Type: corev1.NodeInternalIP, Address: "10.0.1.1"},
+						},
+					},
+				},
+			},
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-pod1",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							internalHostnameAnnotationKey: "internal.a.foo.example.org,internal.b.foo.example.org",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						NodeName:    "my-node1",
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.1.1",
+					},
+				},
+			},
+		},
+		{
 			"create records based on pod's external and internal IPs using DNS Controller annotations",
 			"",
 			"kops-dns-controller",

--- a/source/source.go
+++ b/source/source.go
@@ -111,7 +111,7 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 	if !exists {
 		return nil
 	}
-	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+	return splitHostnameAnnotation(hostnameAnnotation)
 }
 
 func getAccessFromAnnotations(annotations map[string]string) string {
@@ -123,7 +123,11 @@ func getInternalHostnamesFromAnnotations(annotations map[string]string) []string
 	if !exists {
 		return nil
 	}
-	return strings.Split(strings.Replace(internalHostnameAnnotation, " ", "", -1), ",")
+	return splitHostnameAnnotation(internalHostnameAnnotation)
+}
+
+func splitHostnameAnnotation(annotation string) []string {
+	return strings.Split(strings.Replace(annotation, " ", "", -1), ",")
 }
 
 func getAliasFromAnnotations(annotations map[string]string) bool {


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

This PR allows multiple record names separated by commas in the internal-hostname annotation of pods, as is available for services.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
